### PR TITLE
Add install script

### DIFF
--- a/tools/install.fish
+++ b/tools/install.fish
@@ -1,0 +1,6 @@
+pushd
+    git clone https://github.com/fisherman/fisherman ~/.fisherman --depth=1
+    cd ~/.fisherman
+    make
+popd
+exec fish < /dev/tty


### PR DESCRIPTION
Existing fisherman installation script installs fisherman into $PWD, which may be undesirable to many people. I think most users will want fisherman to be installed in somewhere of his/her home directory by default.

Maybe http://install.fisherman.sh can point this file in the near future.

Closes #59