### PR TITLE
Use command when calling non-builtins

### DIFF
--- a/functions/__fisher_file_remove.fish
+++ b/functions/__fisher_file_remove.fish
@@ -8,6 +8,6 @@ function __fisher_file_remove -a plugin file
 
         sed -E "$pattern" < $file > $file.tmp
 
-        mv $file.tmp $file
+        command mv $file.tmp $file
     end
 end

--- a/functions/__fisher_index_update.fish
+++ b/functions/__fisher_index_update.fish
@@ -18,9 +18,9 @@ function __fisher_index_update -a timeout
     end
 
     if not curl --max-time $timeout -sS "$url" > $index
-        rm -f $index
+        command rm -f $index
         return 1
     end
 
-    mv -f $index $fisher_cache/.index
+    command mv -f $index $fisher_cache/.index
 end

--- a/functions/__fisher_key_bindings_disable.fish
+++ b/functions/__fisher_key_bindings_disable.fish
@@ -7,10 +7,10 @@ function __fisher_key_bindings_disable -a plugin user_key_bindings
         > $fisher_key_bindings.tmp \
         < $fisher_key_bindings
 
-    mv -f $fisher_key_bindings.tmp $fisher_key_bindings
+    command mv -f $fisher_key_bindings.tmp $fisher_key_bindings
 
     if test ! -s $fisher_key_bindings
         sed -i.tmp '/__fisher_key_bindings/d' $user_key_bindings
-        rm -f $user_key_bindings.tmp
+        command rm -f $user_key_bindings.tmp
     end
 end

--- a/functions/__fisher_key_bindings_enable.fish
+++ b/functions/__fisher_key_bindings_enable.fish
@@ -2,7 +2,7 @@ function __fisher_key_bindings_enable -a plugin user_key_bindings
     __fisher_key_bindings_update $plugin >> $fisher_key_bindings
 
     if test ! -s $user_key_bindings
-        mkdir -p (dirname $user_key_bindings)
+        command mkdir -p (dirname $user_key_bindings)
 
         printf "%s\n" \
             "function fish_user_key_bindings" \

--- a/functions/__fisher_plugin_enable.fish
+++ b/functions/__fisher_plugin_enable.fish
@@ -39,7 +39,7 @@ function __fisher_plugin_enable -a plugin path
             case --uninstall
             case \*
                 if test "$class" = --man
-                    mkdir -p (dirname $fisher_config/$target)
+                    command mkdir -p (dirname $fisher_config/$target)
                 end
 
                 __fisher_plugin_link $link $source $fisher_config/$target

--- a/functions/__fisher_plugin_link.fish
+++ b/functions/__fisher_plugin_link.fish
@@ -1,3 +1,3 @@
 function __fisher_plugin_link -a options source target
-    ln $options $source $target
+    command ln $options $source $target
 end

--- a/functions/__fisher_plugin_unlink.fish
+++ b/functions/__fisher_plugin_unlink.fish
@@ -1,4 +1,4 @@
 function __fisher_plugin_unlink -a name file
-    rm -f $file
+    command rm -f $file
     functions -e $name
 end

--- a/functions/fisher_install.fish
+++ b/functions/fisher_install.fish
@@ -89,13 +89,13 @@ function fisher_install -d "Install Plugins"
                 set index (math $index + 1)
         end
 
-        mkdir -p $fisher_config/{functions,scripts,completions,conf.d,man} $fisher_cache
+        command mkdir -p $fisher_config/{functions,scripts,completions,conf.d,man} $fisher_cache
 
         set -l path $fisher_cache/$name
 
         if test ! -e $path
             if test -d "$url"
-                ln -sfF $url $path
+                command ln -sfF $url $path
 
             else if not wait "__fisher_url_clone $url $path"
                 printf "fisher: Repository not found: '%s'\n" $url > $stderr

--- a/functions/fisher_uninstall.fish
+++ b/functions/fisher_uninstall.fish
@@ -87,7 +87,7 @@ function fisher_uninstall -d "Uninstall Plugins"
         end
 
         if test "$option" = force
-            rm -rf $path
+            command rm -rf $path
         end
 
         set count (math $count + 1)

--- a/functions/wait.fish
+++ b/functions/wait.fish
@@ -128,12 +128,12 @@ function wait -d "Run commands and display a spinner"
 
     if test -s $tmp
         if test ! -z "$log"
-            nl -n ln -- $tmp > $log
+            nl -n command ln -- $tmp > $log
         end
 
-        rm -f $tmp
+        command rm -f $tmp
         return 1
     end
 
-    rm -f $tmp
+    command rm -f $tmp
 end


### PR DESCRIPTION
By using `command` we ensure that we always end up calling the external
binary and don't get caught by user aliasses, functions or other
magic.

Closes #79

This is a find-replace powered fix, I might have missed something. I purposefully didn't alter the tests so that we could catch any discrepancies.