### PR TITLE
make Fisherman vars transparent

### DIFF
--- a/config.fish
+++ b/config.fish
@@ -1,3 +1,23 @@
+# If fisher_home is not provided, use the directory of this file:
+set -q fisher_home; or set -g fisher_home (dirname (status -f))
+
+# If fisher_config is not provided, set it up:
+set -q fisher_config
+or if test ! -z "$XDG_CONFIG_HOME"
+    set -g fisher_config $XDG_CONFIG_HOME/fisherman
+else
+    # if XDG home is unset or empty, use ~/.config as a fallback
+    set -g fisher_config ~/.config/fisherman
+end
+
+# To not break fish, we need to make sure the config dir exists:
+if test ! -d "$fisher_config"
+    echo "Setting up Fisherman config dir..."
+    mkdir -p "$fisher_config/cache"
+    touch "$fisher_config/fishfile"
+    echo "Done."
+end
+
 set -g fisher_file $fisher_config/fishfile
 set -g fisher_cache $fisher_config/cache
 set -g fisher_binds $fisher_config/key_bindings.fish


### PR DESCRIPTION
This allows a user to include Fisherman through just a single line in their config, they would just need to `source path/to/fisherman/config.fish`. Gaining this transparency, at the same time they can also override the vars if they wish.

As a plus, Fisherman should check for the necessary config directory to be present and create it otherwise. This way people do not need to do it themselves during installation. At the same time, that allows for easy installation to their desires, e.g. to a global path, w/o reverse-engineering the Makefile or installation script. That is also similar to Vundle, dein, and other plugin managers.