### PR TITLE
Usual Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ before_install:
     - sudo apt-get update
     - sudo apt-get -y install fish
 script:
-    - bin/install
-    - fish -c "fisher i fishery/fishtape; fishtape test/*.fish"
+    - sudo make install
+    - mkdir -p ~/.config/fish
+    - echo "source /usr/share/fish/config-fisherman.fish" >> ~/.config/fish/config.fish
+    - fish -c "fisher i fishtape"
+    - fish -c "fishtape test/*.fish"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+sharepath = $(DESTDIR)/usr/share
+fishpath = $(sharepath)/fish
+fisherpath = $(sharepath)/fisherman
+manpath = $(sharepath)/man
+
+.PHONY: all
+all:
+
+.PHONY: install
+install:
+	# prepare directories because install -Dt won't do it on the CI server
+	mkdir -p "$(fisherpath)/completions" "$(fisherpath)/functions"
+	# the main config, which can be sourced by the user
+	install -Dm 644 config-fisherman.fish "$(fishpath)/config-fisherman.fish"
+	install -Dm 644 config.fish "$(fisherpath)/config.fish"
+	install -Dm 644 config-fisherman.fish "$(fishpath)/config-fisherman.fish"
+	# completions
+	install -Dt "$(fisherpath)/completions" completions/*
+	# functions
+	install -Dt "$(fisherpath)/functions" functions/*
+	# man pages, README and LICENSE
+	install -Dt "$(manpath)/man1" man/man1/*
+
+.PHONY: clean
+clean:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@
 curl -sL get.fisherman.sh | fish
 ```
 
+## Packaging
+
+Fisherman supports the [DESTDIR convention](https://www.gnu.org/prep/standards/html_node/DESTDIR.html). Using the Makefile (`DESTDIR` should be adjusted with respect to your OS/distribution or simply not provided):
+```bash
+make install DESTDIR=/path/to/stage
+```
+
+### Usage prerequisites
+
+In order for users who install the package to actually use Fisherman, they need to source the provided `/usr/share/fish/config-fisherman.git`. In your package, you should thus provide a hint such as the following:
+
+Please run `echo "source /usr/share/fish/config-fisherman.git" >> ~/.config/fish/config.fish` to enable Fisherman for your current user.
+
 ## Usage
 
 Install plugins.

--- a/config-fisherman.fish
+++ b/config-fisherman.fish
@@ -1,0 +1,21 @@
+# If fisher_home is not provided, use the global directory:
+set -q fisher_home; or set -g fisher_home (dirname (status -f))/../fisherman
+
+# If fisher_config is not provided, set it up:
+set -q fisher_config
+or if test ! -z "$XDG_CONFIG_HOME"
+    set -g fisher_config $XDG_CONFIG_HOME/fisherman
+else
+    # if XDG home is unset or empty, use ~/.config as a fallback
+    set -g fisher_config ~/.config/fisherman
+end
+
+# To not break fish, we need to make sure the config dir exists:
+if test ! -d "$fisher_config"
+    echo "Setting up Fisherman config dir..."
+    mkdir -p "$fisher_config/cache"
+    touch "$fisher_config/fishfile"
+    echo "Done."
+end
+
+source "$fisher_home/config.fish"


### PR DESCRIPTION
A `Makefile` usually offers two things, allowing for easy packaging and installation:
- a `make` step which creates a build (not yet necessary for Fisherman)
- a `make install` step which copies the resulting files to a given `$PREFIX` directory

So you could run e.g. `PREFIX=/usr/local make && make install`.

The current Makefile, however, manipulates a user's `config.fish` without their consent and doesn't create something like a build. This means that packagers cannot use it at all and have to find their own way of copying the files, figuring out which are needed and where to put them, etc..

I haven't yet really investigated the `make test` step, but it should finally be offered as well. It should be possible to run it easily, but currently requires `fishtape` to be present.