### PR TITLE
For some reason a \ line continuation followed by a | at the beginning

### DIFF
--- a/functions/__fisher_plugin_validate.fish
+++ b/functions/__fisher_plugin_validate.fish
@@ -38,8 +38,7 @@ function __fisher_plugin_validate -a plugin
                 return 1
             end
 
-            printf "%s\n" "$plugin" \
-                | sed -E "
+            printf "%s\n" "$plugin" | sed -E "
                     s|^gh[:/]+|https://github.com/|
                     s|^gl[:/]+|https://gitlab.com/|
                     s|^bb[:/]+|https://bitbucket.org/|
@@ -48,7 +47,6 @@ function __fisher_plugin_validate -a plugin
                     s|^(gist\.github\.com.*)|https://\1|
                     s|^http(s?)[:/]*|http\1://|
                     s|https://github((.com)?/)?|https://github.com/|
-                    s|/*(\.git/*)*\$||g" \
-                | tr "[A-Z]" "[a-z]"
+                    s|/*(\.git/*)*\$||g" | tr "[A-Z]" "[a-z]"
     end
 end


### PR DESCRIPTION
of the next line has problems, at least on my machine running cygwin.
It produced an error like this:
~/.local/share/fisherman/functions/__fisher_plugin_validate.fish (line
42):                 | sed -E "
^ from sourcing file
~/.local/share/fisherman/functions/__fisher_plugin_validate.fish
called on standard input

This change simply eliminates the \ line continuation and instead
concatenates with the next line.  It seems simple enough and avoids
this problem, making it work on cygwin.