### PR TITLE
eliminate -F for ln for OpenBSD by abstracting ln flags

### DIFF
--- a/fisher.fish
+++ b/fisher.fish
@@ -39,6 +39,12 @@ function fisher
         set -g fisher_bundle "$fish_config/fishfile"
     end
 
+    if test (uname -s) = "OpenBSD"
+        set ln_flags = "-sf"
+    else
+        set ln_flags = "-sfF"
+    end
+
     if not command mkdir -p "$fish_config/"{conf.d,functions,completions} "$fisher_config" "$fisher_cache"
         __fisher_log error "
             I couldn't create the fisherman configuration.
@@ -368,7 +374,7 @@ function __fisher_plugin_fetch_items
         end
 
         if test -d "$i"
-            command ln -sfF "$i" "$fisher_config/$names[1]"
+            command ln $ln_flags "$i" "$fisher_config/$names[1]"
             set links $links "$names[1]"
             continue
         end
@@ -378,7 +384,7 @@ function __fisher_plugin_fetch_items
         if test -z "$names[2]"
             if test -d "$source"
                 if test -L "$source"
-                    command ln -sfF "$source" "$fisher_config"
+                    command ln $ln_flags "$source" "$fisher_config"
                 else
                     command cp -rf "$source" "$fisher_config"
                 end
@@ -613,7 +619,7 @@ function __fisher_plugin_enable -a path
 
         set -l target "$fish_config/$dir/$base"
 
-        command ln -sfF "$file" "$target"
+        command ln $ln_flags "$file" "$target"
         builtin source "$target"
 
         if test "$base" = "set_color_custom.fish"
@@ -624,19 +630,19 @@ function __fisher_plugin_enable -a path
 
     for file in $path/conf.d/*.{py,awk}
         set -l base (basename "$file")
-        command ln -sfF "$file" "$fish_config/conf.d/$base"
+        command ln $ln_flags "$file" "$fish_config/conf.d/$base"
     end
 
     for file in $path/{functions/,}*.{py,awk}
         set -l base (basename "$file")
-        command ln -sfF "$file" "$fish_config/functions/$base"
+        command ln $ln_flags "$file" "$fish_config/functions/$base"
     end
 
     for file in $path/conf.d/*.fish
         set -l base (basename "$file")
         set -l target "$fish_config/conf.d/$base"
 
-        command ln -sfF "$file" "$target"
+        command ln $ln_flags "$file" "$target"
         builtin source "$target"
     end
 
@@ -644,7 +650,7 @@ function __fisher_plugin_enable -a path
         set -l base (basename "$file")
         set -l target "$fish_config/completions/$base"
 
-        command ln -sfF "$file" "$target"
+        command ln $ln_flags "$file" "$target"
         builtin source "$target"
     end
 


### PR DESCRIPTION
OpenBSD's ````ln```` does not support the -F flag. This PR drops the flag, only for OpenBSD, so as not to change the behavior for other OSes.