### PR TITLE
use /bin/date replace perl to get get_epoch_in_ms

### DIFF
--- a/fisher.fish
+++ b/fisher.fish
@@ -1740,7 +1740,7 @@ function __fisher_get_epoch_in_ms -a elapsed
         set elapsed 0
     end
 
-    perl -MTime::HiRes -e 'printf("%.0f\n", (Time::HiRes::time() * 1000) - '$elapsed')'
+    math (command date +%s%3N) - $elapsed
 end
 
 

--- a/fisher.fish
+++ b/fisher.fish
@@ -1740,7 +1740,12 @@ function __fisher_get_epoch_in_ms -a elapsed
         set elapsed 0
     end
 
-    math (command date +%s%3N) - $elapsed
+    switch (uname)
+        case Darwin
+            perl -MTime::HiRes -e 'printf("%.0f\n", (Time::HiRes::time() * 1000) - '$elapsed')'
+        case '*'
+            math (command date +%s%3N) - $elapsed
+    end
 end
 
 

--- a/fisher.fish
+++ b/fisher.fish
@@ -1740,7 +1740,7 @@ function __fisher_get_epoch_in_ms -a elapsed
         set elapsed 0
     end
 
-    switch (uname)
+    switch (command uname)
         case Darwin
             perl -MTime::HiRes -e 'printf("%.0f\n", (Time::HiRes::time() * 1000) - '$elapsed')'
         case '*'

--- a/fisher.fish
+++ b/fisher.fish
@@ -1735,17 +1735,23 @@ function __fisher_get_key
 end
 
 
-function __fisher_get_epoch_in_ms -a elapsed
-    if test -z "$elapsed"
-        set elapsed 0
-    end
+switch (command uname)
+    case Darwin
+        function __fisher_get_epoch_in_ms -a elapsed
+            if test -z "$elapsed"
+                set elapsed 0
+            end
 
-    switch (command uname)
-        case Darwin
             perl -MTime::HiRes -e 'printf("%.0f\n", (Time::HiRes::time() * 1000) - '$elapsed')'
-        case '*'
+        end
+    case '*'
+        function __fisher_get_epoch_in_ms -a elapsed
+            if test -z "$elapsed"
+                set elapsed 0
+            end
+
             math (command date +%s%3N) - $elapsed
-    end
+        end
 end
 
 


### PR DESCRIPTION
in my virtual box
````bash
[root@localhost ~]# cat /etc/issue
CentOS release 6.5 (Final)
Kernel \r on an \m
````

and when i run command
````bash
fisher simple
````

i got 
````bash
Can't locate Time/HiRes.pm in @INC (@INC contains: /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 .).
````

i find we use
 
````bash
perl -MTime::HiRes -e 'printf("%.0f\n", (Time::HiRes::time() * 1000) - '$elapsed')'
````
 to get millisecond, but in my host i dont have install Time-HiRes module.  i do install with `yum install perl-Time-HiRes` so that resolve it

are there something i missing?  so just use /bin/date to replace.

code LGTM. But i'm not sure whether it's always right. maybe we should add test:)
