### PR TITLE
Fixed a typo: fin_index_update_interval

### DIFF
--- a/fisher.fish
+++ b/fisher.fish
@@ -935,7 +935,7 @@ function __fisher_remote_index_update
     set -l interval 3240
 
     if test ! -z "$fisher_index_update_interval"
-        set interval "$fin_index_update_interval"
+        set interval "$fisher_index_update_interval"
     end
 
     if test -s "$index"


### PR DESCRIPTION
It's a tiny little typo fix. I noticed it while reading the `__fisher_remote_index_update` function code.