### PR TITLE
`fisher up` obeys $fish_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,17 @@ The configuration and cache are saved to ~/.config/fisherman and ~/.cache/fisher
 
 The fishfile and plugins are saved to ~/.config/fish by default.
 
-To customize this location:
+To customize this location, add the following to your ~/.config/fish/config.fish file:
 
 ```fish
-set -U fish_path ~/my/path
+set -g fish_path ~/my/path
+
+for file in $fish_path/conf.d/*.fish
+  builtin source $file ^ /dev/null
+end
+
+set fish_function_path $fish_path/functions $fish_function_path
+set fish_complete_path $fish_path/completions $fish_complete_path
 ```
 
 ### What is a fishfile and how do I use it?

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The fishfile and plugins are saved to ~/.config/fish by default.
 To customize this location, add the following to your ~/.config/fish/config.fish file:
 
 ```fish
-set -g fish_path ~/my/path
+set -U fish_path ~/my/path
 
 for file in $fish_path/conf.d/*.fish
   builtin source $file ^ /dev/null

--- a/fisher.fish
+++ b/fisher.fish
@@ -686,11 +686,11 @@ end
 function __fisher_self_update
     set -l file (status --current-filename)
 
-    if test "$file" != "$fish_config/functions/$fisher_cmd_name.fish"
+    if test "$file" != "$fish_path/functions/$fisher_cmd_name.fish"
         return 1
     end
 
-    set -l completions "$fish_config/completions/$fisher_cmd_name.fish"
+    set -l completions "$fish_path/completions/$fisher_cmd_name.fish"
     set -l raw_url "https://raw.githubusercontent.com/fisherman/fisherman/master/fisher.fish"
     set -l fake_qs (date "+%s")
 


### PR DESCRIPTION
Previously, running `fisher up` would always write fisher.fish to $fish_config/completions, even if $fish_path had been set.

This branch fixes that, and updates the README to reflect the extra steps required to source snippets and discover functions and completions installed by fisherman when using $fish_path.

Refs #391