### PR TITLE
improve index file parsing

### DIFF
--- a/fisher.fish
+++ b/fisher.fish
@@ -1166,15 +1166,15 @@ function __fisher_remote_index_update
         }
 
         {
-            if (match($0, /^name:[[:space:]]?/)) {
+            if (match($0, /^name:[[:blank:]]*/)) {
                 name = substr($0, RLENGTH+1)
             }
 
-            if (match($0, /^description:[[:space:]]?/)) {
+            if (match($0, /^description:[[:blank:]]*/)) {
                 description = substr($0, RLENGTH+1)
             }
 
-            if (match($0, /^stargazers_count:[[:space:]]?/)) {
+            if (match($0, /^stargazers_count:[[:blank:]]*/)) {
                 stars = substr($0, RLENGTH+1)
             }
 

--- a/fisher.fish
+++ b/fisher.fish
@@ -1166,16 +1166,16 @@ function __fisher_remote_index_update
         }
 
         {
-            if ($0 ~ /^name: /) {
-                name = substr($0, 7)
+            if (match($0, /^name:[[:space:]]?/)) {
+                name = substr($0, RLENGTH+1)
             }
 
-            if ($0 ~ /^description: /) {
-                info = substr($0, 14)
+            if (match($0, /^description:[[:space:]]?/)) {
+                description = substr($0, RLENGTH+1)
             }
 
-            if ($0 ~ /^stargazers_count: /) {
-                stars = substr($0, 19)
+            if (match($0, /^stargazers_count:[[:space:]]?/)) {
+                stars = substr($0, RLENGTH+1)
             }
 
             if (name != "" && stars != "") {


### PR DESCRIPTION
For some reason index file was generated without space after first semicolon for me.
Using awk's match() function and RLENGTH to extract substring (either with space of without) resolves https://github.com/fisherman/fisherman/issues/399.