### PR TITLE
Add info about generating github token in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ You can export the GITHUB_USER and GITHUB_TOKEN environment variables in your sh
 set -x GITHUB_USER your_username
 set -x GITHUB_TOKEN your_github_api_token_for_fisherman
 ```
+If you don't have a GitHub API token, you can [generate one from account settings](https://blog.github.com/2013-05-16-personal-api-tokens/)
 
 [slack-link]: https://fisherman-wharf.herokuapp.com
 [slack-badge]: https://fisherman-wharf.herokuapp.com/badge.svg


### PR DESCRIPTION
A (now outdated) guide was present in https://github.com/fisherman/fisherman/pull/314 which led me to searching for the link I've added

I don't think it's immediately clear what `your_github_api_token_for_fisherman` should be. 