### PR TITLE
Fix awk parser to set correct variable. (ls-remote was failing to display %info tag correctly)

### DIFF
--- a/fisher.fish
+++ b/fisher.fish
@@ -1171,7 +1171,7 @@ function __fisher_remote_index_update
             }
 
             if (match($0, /^description:[[:blank:]]*/)) {
-                description = substr($0, RLENGTH+1)
+                info = substr($0, RLENGTH+1)
             }
 
             if (match($0, /^stargazers_count:[[:blank:]]*/)) {


### PR DESCRIPTION
The awk json parsing routine was setting a variable of "description"
instead of "info". This was causing a problem where the cached index -
and subsequently ls-remote commands - to show the "%info" format item as
the URL again.