### PR TITLE
Add fisherman logo to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@
 [Français]: https://github.com/fisherman/fisherman/wiki/Fran%C3%A7ais
 [Türkçe]: https://github.com/fisherman/fisherman/wiki/T%C3%BCrk%C3%A7e
 
-# [fisherman]
-[![fisherman-logo]]
+![fisherman-logo]
 
 [![Build Status][travis-badge]][travis-link]
 [![Slack][slack-badge]][slack-link]
 
-The [fish-shell] plugin manager.
+[fisherman] is a [fish-shell] plugin manager.
 
 Translations: [日本語], [繁體中文], [简体中文], [한국어], [Русский], [Português], [Türkçe], [Español], [Français], [Català], [Deutsch], [فارسی].
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [Türkçe]: https://github.com/fisherman/fisherman/wiki/T%C3%BCrk%C3%A7e
 
 # [fisherman]
-[fisherman-logo]
+[![fisherman-logo]]
 
 [![Build Status][travis-badge]][travis-link]
 [![Slack][slack-badge]][slack-link]
@@ -205,4 +205,4 @@ If you don't have a GitHub API token, you can [generate one from account setting
 [fish]: https://github.com/fish-shell/fish-shell
 [fish-shell]: https://github.com/fish-shell/fish-shell
 [fisherman]: https://fisherman.github.io
-[fisherman-logo]: https://raw.githubusercontent.com/fisherman/logo/master/fisherman.svg
+[fisherman-logo]: https://raw.githubusercontent.com/fisherman/logo/master/fisherman.svg?sanitize=true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [Türkçe]: https://github.com/fisherman/fisherman/wiki/T%C3%BCrk%C3%A7e
 
 # [fisherman]
+[fisherman-logo]
 
 [![Build Status][travis-badge]][travis-link]
 [![Slack][slack-badge]][slack-link]
@@ -204,3 +205,4 @@ If you don't have a GitHub API token, you can [generate one from account setting
 [fish]: https://github.com/fish-shell/fish-shell
 [fish-shell]: https://github.com/fish-shell/fish-shell
 [fisherman]: https://fisherman.github.io
+[fisherman-logo]: https://raw.githubusercontent.com/fisherman/logo/master/fisherman.svg


### PR DESCRIPTION
I noticed that fisherman has had a logo for a long time but for some reason it doesn't show up on the GitHub home page, most likely the most-prominent, most high-traffic, face of fisherman. I hope that by adding the logo fisherman will appear more profession and gain a greater market share of users.

Note that by adding the logo on top, I displaced the original link to the plugins homepage so I incorporated the link into the one-liner description.