### PR TITLE
Add support for private or protected fish plugins

### DIFF
--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -98,7 +98,7 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
 
                         echo Fetching (set_color --underline)\$url(set_color normal)
 
-                        if curl --silent -L \$url | tar -xzC \$temp -f - 2>/dev/null
+                        if curl --silent -L -n \$url | tar -xzC \$temp -f - 2>/dev/null
                             command cp -Rf \$temp/*/* $source
                         else
                             echo fisher: Invalid plugin name or host unavailable: \\\"$plugin\\\" >&2


### PR DESCRIPTION
## Context

I have a specific use case where a set of fish plugins are made available internally. They are not public Github repositories. The `curl` command used by fisher will only fetch plugins from public repositories. 

## Proposed Changes

By changing the command to `curl -n` it can take advantage of any credentials stored in the `~/.netrc` file. This may not be the best flag to have enabled by default, or perhaps goes against the spirit of sharing fish plugins publicly. An alternative could be to move this behind a variable or some other indicator to mark that a plugin is private.