### PR TITLE
Initialize _fisher_plugins using fish_plugins file (#741)

### DIFF
--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -2,6 +2,8 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
     set --query fisher_path || set --local fisher_path $__fish_config_dir
     set --local fisher_version 4.4.3
     set --local fish_plugins $__fish_config_dir/fish_plugins
+    test -e $fish_plugins && set --local file_plugins (string match --regex -- '^[^\s]+$' <$fish_plugins)
+    set --query _fisher_plugins || set --universal _fisher_plugins $file_plugins
 
     switch "$cmd"
         case -v --version
@@ -28,8 +30,6 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
             set --local arg_plugins $argv[2..-1]
             set --local old_plugins $_fisher_plugins
             set --local new_plugins
-
-            test -e $fish_plugins && set --local file_plugins (string match --regex -- '^[^\s]+$' <$fish_plugins)
 
             if ! set --query argv[2]
                 if test "$cmd" != update


### PR DESCRIPTION
This change is for users who commit fish_plugins and plugin sources but omit fish_variables.

On a system where Fisher's universal variables are unset, most Fisher commands do not work out-of-the-box:

* `fisher list [<regex>]`
  * returns nothing
* `fisher remove repo/plugin`
  * fails with error: "Plugin not installed: repo/plugin"
* `fisher update repo/plugin`
  * fails with error: "Plugin not installed: repo/plugin"
* `fisher update`
  * fails with error about conflicting files, deletes fish_plugins file
* `fisher install repo/plugin`
  * if fish_plugins contains the plugin, same behavior as bare `fisher update`
  * otherwise, installs the plugin, rewrites fish_plugins file with only "repo/plugin"

As of this commit all Fisher commands work except for `fisher remove`. Fisher still has no way of knowing which files to remove absent the universal variable that tracks the files associated to a plugin. It may make sense to reject calls like `fisher remove repo/plugin` if the `_fisher_repo_2F_plugin_files` universal variable is missing. Fisher could suggest the user run `fisher update` and try again.

Note: I haven't really investigated how this works with local plugins since I don't use those.

Attempt to fix https://github.com/jorgebucaran/fisher/issues/741.