### PR TITLE
Document autoinstall (bootstrap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ Manage functions, completions, bindings, and snippets from the command line. Ext
 curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
 ```
 
+### Automatic install
+
+If you want to automatically install fisher when it is not present, you can add
+the following at the top of your `~/.config/fish/config.fish`.
+If `fish_plugins` is present is readed first.
+
+```fish
+if not functions -q fisher; curl -sL https://git.io/fisher | source && fisher update || fisher install jorgebucaran/fisher; end
+```
+
 ## Quickstart
 
 You can install, update, and remove plugins interactively with Fisher, taking advantage of Fish [tab completion](https://fishshell.com/docs/current/index.html#completion) and rich syntax highlighting.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ the following at the top of your `~/.config/fish/config.fish`.
 If `fish_plugins` is present is readed first.
 
 ```fish
-if not functions -q fisher; curl -sL https://git.io/fisher | source && fisher update || fisher install jorgebucaran/fisher; end
+if not functions -q fisher && status is-interactive
+    curl -sL https://git.io/fisher | source && fisher update || fisher install jorgebucaran/fisher
+end
 ```
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher
 
 If you want to automatically install fisher when it is not present, you can add
 the following at the top of your `~/.config/fish/config.fish`.
-If `fish_plugins` is present is readed first.
+If `fish_plugins` is present, it is read first.
 
 ```fish
 if not functions -q fisher && status is-interactive


### PR DESCRIPTION
This started in #748, and is a partial PR from #749.
Instead of directly doing a `fisher install jorgebucaran/fisher`, it is recommended to try to `fisher update` first. This honors a maybe presente `fish_plugins` file.