### PR TITLE
Support arbitrary git hosts

### DIFF
--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -226,6 +226,13 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
                 contains -- $plugin $install_plugins && set --local event install || set --local event update
 
                 printf "%s\n" Installing\ (set_color --bold)$plugin(set_color normal) "           "(string replace --regex -- '^'$HOME '~' $$plugin_files_var)
+
+                for file in (string match --regex -- '.+/[^/]+\.fish$' $$plugin_files_var | string replace --regex -- '^'$HOME '~')
+                    source $file
+                    if set --local name (string replace --regex -- '.+conf\.d/([^/]+)\.fish$' '$1' $file)
+                        emit {$name}_$event
+                    end
+                end
             end
 
             command rm -rf $source_plugins

--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -227,7 +227,7 @@ function fisher --argument-names cmd --description "A plugin manager for Fish"
 
                 printf "%s\n" Installing\ (set_color --bold)$plugin(set_color normal) "           "(string replace --regex -- '^'$HOME '~' $$plugin_files_var)
 
-                for file in (string match --regex -- '.+/[^/]+\.fish$' $$plugin_files_var | string replace --regex -- '^'$HOME '~')
+                for file in (string match --regex -- '.+/[^/]+\.fish$' $$plugin_files_var | string replace -- \~ ~)
                     source $file
                     if set --local name (string replace --regex -- '.+conf\.d/([^/]+)\.fish$' '$1' $file)
                         emit {$name}_$event

--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -32,6 +32,7 @@ function __fisher_fetch_plugin --argument-names plugin source
                 echo "fisher: Invalid git repo or host unavailable: $plugin" >&2
                 command rm -rf $source
             end
+
         # GitHub tarball download (default)
         else
             set --local url https://api.github.com/repos/$repo[1]/tarball/$repo[2]

--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -7,6 +7,9 @@ function __fisher_fetch_plugin --argument-names plugin source
         command cp -Rf $plugin/* $source
     else
         set --local temp (command mktemp -d)
+        # Trap EXIT to always clean up temp dir
+        trap "command rm -rf $temp" EXIT
+
         set --local repo (string split -- \@ $plugin) || set repo[2] HEAD
         set --local name
 
@@ -44,13 +47,6 @@ function __fisher_fetch_plugin --argument-names plugin source
                 command rm -rf $source
             end
         end
-
-        command rm -rf $temp
-    end
-
-    # Check for .fish files in the plugin source (validation)
-    if count $source/*.fish > /dev/null
-        # .fish files exist
     end
 end
 

--- a/functions/fisher.fish
+++ b/functions/fisher.fish
@@ -15,8 +15,8 @@ function __fisher_fetch_plugin --argument-names plugin source
     test -z "$tag" && set tag HEAD
 
     # GitLab tarball
-    if string match -q "gitlab.com/*" $repo
-        set --local path (string replace --regex -- '^gitlab.com/' '' $repo)
+    if string match -rq '^(https://)?gitlab.com/' $repo
+        set --local path (string replace --regex -- '^https?://gitlab.com/' '' $repo)
         set --local name (string split -- / $path)[-1]
         set --local url https://gitlab.com/$path/-/archive/$tag/$name-$tag.tar.gz
         echo Fetching (set_color --underline)$url(set_color normal)


### PR DESCRIPTION
Add support to fetch plugins from arbitrary git hosts via `git clone`. It will use whatever the user's git config is to clone things.

These patterns are now possible:
```
fisher install https://git.sr.ht/~jlkde/note.fish
fisher install git@tangled.sh:himawari.fun/bugstyle.fish
fisher install git@github.com:meaningful-ooo/sponge.git@1.1.0
```

We assume that any URL that doesn't match existing officially supported git hosts like github `user/repo(@ref)?` or `(https?://)?gitlab.com/*` is a git host.

I have tested this with these plugins:
```
jethrokuan/z
https://github.com/jorgebucaran/spark.fish.git
gitlab.com/mirdono/tucker
git@github.com:meaningful-ooo/sponge.git@1.1.0
git@tangled.sh:himawari.fun/bugstyle.fish
https://git.sr.ht/~jlkde/note.fish
```

Fixes #801
Maybe fixes #745 as requests can be authenticated using ssh